### PR TITLE
Implement tracks playback functionality

### DIFF
--- a/src/spotify/client.py
+++ b/src/spotify/client.py
@@ -56,6 +56,31 @@ class SpotifyAPI:
 
         return response.json()
 
+    @staticmethod
+    def get_audio_preview_url(response: dict) -> str:
+        """
+        Fetches link to audiofile (audio_preview_url) from `episodes` block in callback Spotify API answer.
+
+        :param response: JSON Spotify API .
+        :return: Link to audiofile or error message.
+        """
+        try:
+            episodes = response.get("episodes", {})
+            items = episodes.get("items", [])
+
+            if not items:
+                return "❌ Нет доступных эпизодов с предпрослушиванием."
+
+            first_episode = items[0]
+            audio_preview_url = first_episode.get("audio_preview_url")
+
+            if audio_preview_url:
+                return audio_preview_url
+            else:
+                return "❌ У данного эпизода нет доступного предпрослушивания."
+        except Exception as e:
+            return f"❌ Произошла ошибка: {str(e)}"
+
 
 if __name__ == "__main__":
     spotify = SpotifyAPI()

--- a/src/telegram_bot/bot.py
+++ b/src/telegram_bot/bot.py
@@ -4,6 +4,7 @@ from aiogram import Bot, Dispatcher
 from config.settings import TELEGRAM_BOT_TOKEN, DATABASE_URL
 from src.telegram_bot.database import Database
 from src.telegram_bot.main_handlers import register_main_handlers
+from src.telegram_bot.playback_handlers import register_playback_handlers
 from src.telegram_bot.playlist_handlers import register_playlist_handlers
 from aiogram.dispatcher.middlewares.base import BaseMiddleware
 from aiogram.types.base import TelegramObject
@@ -38,6 +39,7 @@ async def main():
     dp.update.middleware(DbMiddleware(db))
     register_main_handlers(dp)
     register_playlist_handlers(dp)
+    register_playback_handlers(dp)
 
     try:
         logging.info("Бот запущен!")

--- a/src/telegram_bot/main_handlers.py
+++ b/src/telegram_bot/main_handlers.py
@@ -47,7 +47,8 @@ async def help_command_handler(message: Message):
         "- /delete_playlist название: Удалить плейлист\n"
         "- /add_to_playlist название_плейлиста track_id: Добавить трек в плейлист\n"
         "- /remove_from_playlist название_плейлиста track_id: Удалить трек из плейлиста\n"
-        "- /playlists: Показать все ваши плейлисты (каждый плейлист — отдельным сообщением с кнопкой для просмотра содержимого)\n\n"
+        "- /playlists: Показать все ваши плейлисты (каждый плейлист — отдельным сообщением с кнопкой для просмотра содержимого)\n"
+        "- /play track_name_or_id: Предоставить 30-секундный фрагмент аудиофайла указанного трека из Spotify\n\n"
     )
     await message.answer(help_text, parse_mode="HTML")
 

--- a/src/telegram_bot/playback_handlers.py
+++ b/src/telegram_bot/playback_handlers.py
@@ -1,0 +1,74 @@
+from aiogram.filters import Command, CommandObject
+from aiogram.types import Message
+from main_handlers import spotify
+
+
+async def play_command_handler(message: Message, command: CommandObject):
+    """
+    Handler for /play command.
+    Fetches a track by its name or ID from Spotify and sends a 30-second preview to the user.
+    """
+    if not command.args:
+        await message.reply(
+            "Пожалуйста, укажите название трека, ID трека или эпизода. Пример: /play Imagine Dragons"
+        )
+        return
+
+    query = command.args.strip()
+    try:
+        results = spotify.search(query, search_type="track", limit=1)
+        tracks = results.get("tracks", {}).get("items", [])
+        episodes = results.get("episodes", {}).get("items", [])
+        print(results)
+        if not tracks and not episodes:
+            await message.reply("Ничего не найдено. Попробуйте другой запрос.")
+            return
+
+        if tracks:
+            track = tracks[0]
+            track_name = track.get("name", "Unknown Track")
+            artists = ", ".join(artist["name"] for artist in track.get("artists", []))
+            preview_url = track.get("preview_url")
+
+            if not preview_url:
+                await message.reply(
+                    f"К сожалению, для трека '{track_name}' ({artists}) нет доступного предпрослушивания."
+                )
+                return
+
+            audio_data = await spotify.download_preview(preview_url)
+
+            await message.answer_audio(
+                audio=audio_data,
+                title=track_name,
+                performer=artists,
+                caption=f"🎵 {track_name}\n👤 {artists}",
+            )
+            return
+
+        if episodes:
+            episode = episodes[0]
+            print(episode)
+            episode_name = episode.get("name", "Unknown Episode")
+            preview_url = episode.get("audio_preview_url")
+
+            if not preview_url:
+                await message.reply(
+                    f"К сожалению, для эпизода '{episode_name}' нет доступного предпрослушивания."
+                )
+                return
+
+            audio_data = await spotify.download_preview(preview_url)
+
+            await message.answer_audio(
+                audio=audio_data,
+                title=episode_name,
+                caption=f"🎧 {episode_name}\nПредпрослушивание эпизода.",
+            )
+            return
+    except Exception as e:
+        await message.reply(f"Произошла ошибка: {e}")
+
+
+def register_playback_handlers(dp):
+    dp.message.register(play_command_handler, Command("play"))


### PR DESCRIPTION
### Related issue

Closes #10

### List of changes

Allow users to play tracks by their `id` or `name`.
- Implement a `/play` command to start playback for a specific playlist or track.
- Provide audio files for playback within the Spotify app.
- Test playback functionality for accuracy and reliability.